### PR TITLE
Fixed for internal IP's that start with 127 that aren't loopback, and…

### DIFF
--- a/hs100.sh
+++ b/hs100.sh
@@ -2,8 +2,6 @@
 
 set -o errexit
 
-here=$(me=`readlink -f ${BASH_SOURCE[0]}`; cd `dirname $me`; echo $PWD)
-
 ##
 #  Switch the TP-LINK HS100 wlan smart plug on and off, query for status
 #  Tested with firmware 1.0.8
@@ -197,11 +195,11 @@ query_plug(){
 
 # plug commands
 cmd_discover(){
-    myip=`${here}/myip.sh`
+    myip=`./myip.sh`
     subnet=$(echo $myip | egrep -o '([0-9]{1,3}\.){3}')
     subnet=${subnet}0-255
     declare -a hs100ip
-    hs100ip=( $(nmap -p ${port} --open ${subnet} \
+    hs100ip=( $(nmap -Pn -p ${port} --open ${subnet} \
                 | grep 'Nmap scan report for' \
                 | egrep -o '(([0-9]{1,3}\.){3}[0-9]{1,3})' ) \
             ) \

--- a/myip.sh
+++ b/myip.sh
@@ -10,14 +10,14 @@ if [ -n $ipconfig ] && ! [ -n $ifconfig ]
 then
     ipconfig \
         | grep 'IPv4 Address' \
-        | grep -v '127.0.0.1' \
+        | grep -v ' 127.' \
         | egrep -o '(([0-9]{1,3}\.){3}[0-9]{1,3})'
 # osx and linux have ifconfig
 elif [ -n $ifconfig ]
 then
     ifconfig \
         | grep '^\s*inet[^6]' \
-        | grep -v '127.0.0.1' \
+        | grep -v ' 127.' \
         | egrep -o '(([0-9]{1,3}\.){3}[0-9]{1,3})'\
         | head -n 1
 else


### PR DESCRIPTION
… removed readlink to allow multi-platform compatibility, however, must run scripts in same dirs, and fixed problem with nmap where ping isn't allowed on Wi-Fi router on internal network.